### PR TITLE
Update deployment documentation

### DIFF
--- a/.kiro/specs/dependency-resolution/tasks.md
+++ b/.kiro/specs/dependency-resolution/tasks.md
@@ -57,7 +57,7 @@
   - Verify hot module replacement works correctly in development
   - _Requirements: 1.1, 1.2, 1.3, 1.4, 4.1, 4.2, 4.3_
 
-- [ ] 8. Validate TypeScript 5.9 compilation and modern features
+- [x] 8. Validate TypeScript 5.9 compilation and modern features
   - Run npm run type-check to verify TypeScript 5.9 compilation works correctly
   - Test TypeScript compilation in Vite development mode
   - Fix any type errors that arise from React 18.3.x or TypeScript 5.9 upgrades
@@ -65,7 +65,7 @@
   - Test that modern TypeScript 5.9 features are available and working
   - _Requirements: 2.2, 2.3, 2.4, 2.5_
 
-- [ ] 9. Validate modern ESLint functionality
+- [x] 9. Validate modern ESLint functionality
   - Run npm run lint to test ESLint 9.x configuration with updated plugins
   - Verify ESLint rules are applied correctly to existing code
   - Fix any linting configuration issues that arise from ESLint 9.x migration
@@ -73,24 +73,7 @@
   - Verify TypeScript ESLint 8.x rules work with TypeScript 5.9
   - _Requirements: 8.3, 8.4, 8.5_
 
-- [ ] 10. Test MUI v7 component rendering with React 19
-  - Start Vite development server and verify all MUI components render correctly
-  - Test theme application and styling with MUI v7 and modern styling approaches
-  - Verify Material-UI icons display correctly with React 19
-  - Check that emotion styling dependencies work correctly with MUI v7 and React 19
-  - Test responsive design functionality with updated MUI components
-  - _Requirements: 5.4, 5.5_
-
-- [ ] 11. Comprehensive application functionality testing with modern stack
-  - Test interactive map displays and functions correctly with React 19 and Vite
-  - Verify meeting search and filtering functionality works with updated dependencies
-  - Test navigation and routing between pages functions properly with React Router and React 19
-  - Validate meeting update form submission works correctly with modern stack
-  - Test responsive design functionality on different screen sizes
-  - Verify performance improvements from Vite and React 19
-  - _Requirements: 7.1, 7.2, 7.3, 7.4, 7.5, 7.6_
-
-- [ ] 12. Final validation and modern development workflow testing
+- [x] 10. Final validation and modern development workflow testing
   - Perform final npm install test to confirm no --legacy-peer-deps flag needed
   - Run complete Vitest test suite to verify all functionality works correctly
   - Test Vite production build and deployment process with modern dependencies

--- a/README.md
+++ b/README.md
@@ -60,22 +60,19 @@ In the project directory, you can run:
 * `npm run format` - Formats code using Prettier
 * `npm run format:check` - Checks if code is properly formatted
 
-## Deploy Project to Surge
+## Deploy Project to Firebase
+_The following steps assume that you have a firebase account and have set up a project_
 
+### Set up Firebase on your local
 ```
-$ npm install -g surge
+$ npm install -g firebase
+$ firebase login
+```
+
+### Deployment to dev or prod
+```
+$ npm run deploy-dev
+```
+```
 $ npm run deploy
 ```
-
-## Firebase Functions
-
-At present, Quaker Maps is an almost entirely front-end project. There is only one piece of the application that requires a backend call: the UpdateMeetings view, which forwards update meeting requests to an email that we designate.
-
-In order for this functionality to work, we need to ensure that our Firebase function for emailing (`firebase/functions/src/controllers/email.ts`) is properly configured and deployed.
-
-There are currently two steps to setting this up: 
-
-1. From the `firebase` directory, run `$ firebase deploy`
-2. Set up the config variables invoked near the top of `email.ts` as described in the [Firebase documentation](https://firebase.google.com/docs/functions/config-env)
-
-(The URL for our backend call is hard-coded in `send_update_meeting_request`; this might need to be changed if we were to have multiple deployments with different emailing requirements)


### PR DESCRIPTION
We now use firebase hosting instead of surge, because this gives us HTTPS for free.

This change also updates a tasks.md file to reflect what we actually did during our dependency resolution project.